### PR TITLE
Improve get_image_markup() in order to get the most optimized size from Instagram for the given width.

### DIFF
--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -200,16 +200,16 @@ class SI_Shortcodes {
                 }
             }
             else {
-				if ( $width <= $image->images->thumbnail->width ) {
-					$url = $image->images->thumbnail->url;
-				}
-				else if ( $width <= $image->images->low_resolution->width ) {
-					$url = $image->images->low_resolution->url;
-				}
-				else {
-					$url = $image->images->standard_resolution->url;
-				}
-			}
+    			if ( $width <= $image->images->thumbnail->width ) {
+    			    $url = $image->images->thumbnail->url;
+    			}
+    			else if ( $width <= $image->images->low_resolution->width ) {
+    			    $url = $image->images->low_resolution->url;
+    			}
+    			else {
+    			    $url = $image->images->standard_resolution->url;
+    			}
+    		}
 
             // Fix https
             $url = str_replace( 'http://', '//', $url );

--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -199,6 +199,17 @@ class SI_Shortcodes {
                         break;
                 }
             }
+            else {
+				if ( $width <= $image->images->thumbnail->width ) {
+					$url = $image->images->thumbnail->url;
+				}
+				else if ( $width <= $image->images->low_resolution->width ) {
+					$url = $image->images->low_resolution->url;
+				}
+				else {
+					$url = $image->images->standard_resolution->url;
+				}
+			}
 
             // Fix https
             $url = str_replace( 'http://', '//', $url );


### PR DESCRIPTION
Improve web performances, especially if thumbnail size (150x150) is returned instead of standard size (612x612).
